### PR TITLE
Updating to use gulp-uglify-es for ES6 support

### DIFF
--- a/gulp-tasks/scripts.js
+++ b/gulp-tasks/scripts.js
@@ -1,5 +1,5 @@
 var sourcemaps = require('gulp-sourcemaps')
-var uglify = require('gulp-uglify')
+var uglify = require('gulp-uglify-es').default
 var notify = require('gulp-notify')
 
 /**

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "gulp-sourcemaps": "^2.6.5",
         "gulp-svg-sprite": "^1.3.6",
         "gulp-svg2png": "^2.0.0",
-        "gulp-uglify": "^3.0.2",
+        "gulp-uglify-es": "^2.0.0",
         "merge-options": "^1.0.1",
         "node-notifier": "^5.4.0",
         "postcss-browser-reporter": "^0.5.0",


### PR DESCRIPTION
@bmcclure Could you take a look at this proposed change and let me know if you think there would be any problems? I'm not able to use ES6 syntax in a project because gulp-uglify doesn't support it. I switched it to use gulp-uglify-es: https://www.npmjs.com/package/gulp-uglify-es